### PR TITLE
Fix and improve docker instalation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Condominium Administration System
 
 ### laravel-vue-condominium
-<img src="https://laravel.com/img/logomark.min.svg" width="100" height="100"/><img src="https://vuejs.org/images/logo.svg" width="100" height="100"/>
 
+<img src="https://laravel.com/img/logomark.min.svg" width="100" height="100"/><img src="https://vuejs.org/images/logo.svg" width="100" height="100"/>
 
 ![GitHub repo size](https://img.shields.io/github/repo-size/CaribesTIC/laravel-vue-condominium)
 ![GitHub contributors](https://img.shields.io/github/contributors/CaribesTIC/laravel-vue-condominium)
@@ -30,6 +30,7 @@ Linux:
 - Run `docker-compose up -d`
 - Change permission to exectute script.sh file `sudo chmod +x script.sh`
 - Run `./script.sh`
+- Create an alias in the `/etc/hosts` file for the location set in the `VIRTUALHOST`s variable of your web server
 
 ## Contributing to laravel-vue-condominium
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Linux:
 - Run `docker-compose up -d`
 - Change permission to exectute script.sh file `sudo chmod +x script.sh`
 - Run `./script.sh`
-- Create an alias in the `/etc/hosts` file for the location set in the `VIRTUALHOST`s variable of your web server
+- Create an alias in the `/etc/hosts` file for the location set in the VIRTUALHOST environment variable of your web server
 
 ## Contributing to laravel-vue-condominium
 

--- a/script.sh
+++ b/script.sh
@@ -28,15 +28,6 @@ docker exec -w /var/www/html phplaravel_condominium php artisan storage:link
 
 docker exec -w /var/www/html phplaravel_condominium php artisan optimize
 
-HAS_VIRTUALHOST=$(cat /etc/hosts | grep "0.0.0.0    $VIRTUALHOST    www.$VIRTUALHOST" | wc -w)
-
-if [[ $HAS_VIRTUALHOST == "0" ]]
-then
-    echo "Adding an entry to the hosts file requires root privilege (administrator)"
-
-    su -c "echo \"0.0.0.0    $VIRTUALHOST    www.$VIRTUALHOST\" >> /etc/hosts"
-fi
-
 docker exec -w /var/www/html phplaravel_condominium npm run dev
 
 echo "Script execution completed successfully"


### PR DESCRIPTION
The installation script requested the root password to add an entry in the file '/ etc / hosts', if the password was wrong, an error was generated in the execution of the script.

The script was modified so that these root privileges are not requested and the entry in the '/ etc / hosts' file will be done manually at the user's convenience.